### PR TITLE
refactor(auth): consolidate auth flow through AuthContext

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ function GuardedRoute({ children }: { children: React.ReactNode }) {
 }
 
 function AppRoutes() {
-  const { authConfig, isAuthenticated, isLoading, refreshUser } = useAuth();
+  const { authConfig, isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
     return (
@@ -54,7 +54,7 @@ function AppRoutes() {
             element={
               isAuthenticated
                 ? <Navigate to="/" replace />
-                : <LoginPage authConfig={authConfig!} onLoginSuccess={refreshUser} />
+                : <LoginPage />
             }
           />
           <Route
@@ -63,7 +63,7 @@ function AppRoutes() {
               isAuthenticated
                 ? <Navigate to="/" replace />
                 : authConfig!.registration_enabled
-                  ? <RegisterPage onRegisterSuccess={refreshUser} />
+                  ? <RegisterPage />
                   : <Navigate to="/login" replace />
             }
           />

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
-import type { User, Organization, AuthConfig } from '../types';
+import type { User, Organization, AuthConfig, InviteRegisterRequest } from '../types';
 import { authApi } from '../services/api';
 import { setOnAuthFailure } from '../services/api';
 import { setTokens, clearTokens, hasTokens } from '../services/auth';
@@ -13,6 +13,7 @@ interface AuthContextType {
   mustChangePassword: boolean;
   login: (email: string, password: string) => Promise<void>;
   register: (orgName: string, name: string, email: string, password: string) => Promise<void>;
+  registerWithInvite: (data: InviteRegisterRequest) => Promise<void>;
   logout: () => void;
   refreshUser: () => Promise<void>;
 }
@@ -119,6 +120,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setOrganization(res.organization);
   }, []);
 
+  const registerWithInvite = useCallback(async (data: InviteRegisterRequest) => {
+    const res = await authApi.registerWithInvite(data);
+    setTokens(res.access_token, res.refresh_token);
+    setUser(res.user);
+    setOrganization(res.organization);
+  }, []);
+
   return (
     <AuthContext.Provider
       value={{
@@ -130,6 +138,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         mustChangePassword,
         login,
         register,
+        registerWithInvite,
         logout,
         refreshUser,
       }}

--- a/src/pages/InvitePage.tsx
+++ b/src/pages/InvitePage.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import type { InvitePreview, InviteRegisterRequest } from '../types';
 import { authApi } from '../services/api';
-import { setTokens } from '../services/auth';
 import { useAuth } from '../context/AuthContext';
 import { toast } from '../components/Toast';
 import { friendlyError } from '../utils/errors';
@@ -10,7 +9,7 @@ import { friendlyError } from '../utils/errors';
 export function InvitePage() {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
-  const { refreshUser } = useAuth();
+  const { registerWithInvite } = useAuth();
 
   const [preview, setPreview] = useState<InvitePreview | null>(null);
   const [loading, setLoading] = useState(true);
@@ -54,9 +53,7 @@ export function InvitePage() {
     if (!canSubmit || !token) return;
     setSubmitting(true);
     try {
-      const res = await authApi.registerWithInvite({ ...form, token });
-      setTokens(res.access_token, res.refresh_token);
-      await refreshUser();
+      await registerWithInvite({ ...form, token });
       navigate('/', { replace: true });
     } catch (err) {
       toast('error', friendlyError(err, 'Failed to accept invite. Please try again.'));

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,17 +1,12 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import type { LoginRequest, AuthConfig } from '../types';
-import { authApi } from '../services/api';
-import { setTokens } from '../services/auth';
+import type { LoginRequest } from '../types';
+import { useAuth } from '../context/AuthContext';
 import { toast } from '../components/Toast';
 import { friendlyError } from '../utils/errors';
 
-interface LoginPageProps {
-  authConfig: AuthConfig;
-  onLoginSuccess: () => void;
-}
-
-export function LoginPage({ authConfig, onLoginSuccess }: LoginPageProps) {
+export function LoginPage() {
+  const { login, authConfig } = useAuth();
   const [form, setForm] = useState<LoginRequest>({ email: '', password: '' });
   const [loading, setLoading] = useState(false);
 
@@ -20,9 +15,7 @@ export function LoginPage({ authConfig, onLoginSuccess }: LoginPageProps) {
     if (!form.email.trim() || !form.password) return;
     setLoading(true);
     try {
-      const res = await authApi.login(form);
-      setTokens(res.access_token, res.refresh_token);
-      onLoginSuccess();
+      await login(form.email, form.password);
     } catch (err) {
       toast('error', friendlyError(err, 'Login failed. Please check your credentials.'));
     } finally {
@@ -86,7 +79,7 @@ export function LoginPage({ authConfig, onLoginSuccess }: LoginPageProps) {
         </form>
 
         {/* Register link */}
-        {authConfig.registration_enabled && (
+        {authConfig?.registration_enabled && (
           <p className="mt-4 text-center text-sm text-slate-400">
             Don&apos;t have an account?{' '}
             <Link to="/register" className="font-medium text-blue-400 hover:text-blue-300">

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,16 +1,12 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { RegisterRequest } from '../types';
-import { authApi } from '../services/api';
-import { setTokens } from '../services/auth';
+import { useAuth } from '../context/AuthContext';
 import { toast } from '../components/Toast';
 import { friendlyError } from '../utils/errors';
 
-interface RegisterPageProps {
-  onRegisterSuccess: () => void;
-}
-
-export function RegisterPage({ onRegisterSuccess }: RegisterPageProps) {
+export function RegisterPage() {
+  const { register } = useAuth();
   const [form, setForm] = useState<RegisterRequest>({
     org_name: '',
     name: '',
@@ -40,9 +36,7 @@ export function RegisterPage({ onRegisterSuccess }: RegisterPageProps) {
     if (!canSubmit) return;
     setLoading(true);
     try {
-      const res = await authApi.register(form);
-      setTokens(res.access_token, res.refresh_token);
-      onRegisterSuccess();
+      await register(form.org_name, form.name, form.email, form.password);
     } catch (err) {
       toast('error', friendlyError(err, 'Registration failed. Please try again.'));
     } finally {


### PR DESCRIPTION
## Problem

Auth pages (`LoginPage`, `RegisterPage`, `InvitePage`) were bypassing `AuthContext` and calling `authApi` + `setTokens` directly. This created two separate code paths for the same operation, both needing to be kept in sync:

- `LoginPage` called `authApi.login()` + `setTokens()` + `onLoginSuccess()` via prop
- `RegisterPage` called `authApi.register()` + `setTokens()` + `onRegisterSuccess()` via prop
- `InvitePage` called `authApi.registerWithInvite()` + `setTokens()` + `refreshUser()` directly

Any change to the auth flow (e.g. adding org-level state, changing token storage) had to be applied in multiple places.

## Solution

Centralize all auth mutations in `AuthContext`, making it the single source of truth:

- `login()` — already existed, now actually used by `LoginPage`
- `register()` — already existed, now actually used by `RegisterPage`
- `registerWithInvite()` — **new**, added to `AuthContext`; `InvitePage` consumes it

Auth pages become simple consumers of `useAuth()`, with no direct dependency on `authApi` or `setTokens`.

## Changes

| File | Change |
|------|--------|
| `src/context/AuthContext.tsx` | Add `registerWithInvite` to interface + implementation |
| `src/pages/LoginPage.tsx` | Remove props, use `useAuth()` |
| `src/pages/RegisterPage.tsx` | Remove props, use `useAuth()` |
| `src/pages/InvitePage.tsx` | Remove direct `authApi`/`setTokens` calls, use `registerWithInvite` from context |
| `src/App.tsx` | Remove `refreshUser` destructure + props from `LoginPage`/`RegisterPage` renders |

Also fixes a TypeScript strict-null error: `authConfig.registration_enabled` → `authConfig?.registration_enabled` (type is `AuthConfig | null`).

## Testing

- `npm run build` passes with zero TypeScript errors
- Login, register, and invite flows all route through `AuthContext` — state updates are consistent

Closes #<!-- if applicable -->