### PR TITLE
refactor(utils): extract shared formatting helpers to src/utils/format.ts

### DIFF
--- a/src/pages/PostActionDetailPage.tsx
+++ b/src/pages/PostActionDetailPage.tsx
@@ -15,45 +15,10 @@ import { postActionsApi, webhooksApi, schedulesApi } from '../services/api';
 import { toast } from '../components/Toast';
 import { friendlyError } from '../utils/errors';
 
-const METHOD_COLORS: Record<string, string> = {
-  GET: 'bg-green-500/20 text-green-400',
-  POST: 'bg-blue-500/20 text-blue-400',
-  PUT: 'bg-yellow-500/20 text-yellow-400',
-  PATCH: 'bg-orange-500/20 text-orange-400',
-  DELETE: 'bg-red-500/20 text-red-400',
-};
-
-const AUTH_LABELS: Record<string, string> = {
-  none: 'No Auth',
-  bearer: 'Bearer Token',
-  basic: 'Basic Auth',
-  header: 'Custom Header',
-};
-
-const runStatusStyles: Record<string, { bg: string; dot: string; pulse: boolean }> = {
-  success: { bg: 'bg-green-500/20 text-green-400', dot: 'bg-green-400', pulse: false },
-  failed: { bg: 'bg-red-500/20 text-red-400', dot: 'bg-red-400', pulse: false },
-  retrying: { bg: 'bg-yellow-500/20 text-yellow-400', dot: 'bg-yellow-400', pulse: true },
-};
+import { formatDateTime, formatDuration, RUN_STATUS_STYLES, METHOD_COLORS, AUTH_LABELS } from '../utils/format';
 
 const BASE_POLL_INTERVAL = 10_000;
 const MAX_POLL_INTERVAL = 120_000;
-
-function formatDateTime(dateStr: string | null): string {
-  if (!dateStr) return 'N/A';
-  return new Date(dateStr).toLocaleString();
-}
-
-function formatDuration(start: string, end: string | null): string {
-  if (!end) return 'Running...';
-  const ms = new Date(end).getTime() - new Date(start).getTime();
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainSec = seconds % 60;
-  return `${minutes}m ${remainSec}s`;
-}
 
 export function PostActionDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -480,7 +445,7 @@ export function PostActionDetailPage() {
               </thead>
               <tbody className="divide-y divide-slate-800">
                 {runs.map((run) => {
-                  const style = runStatusStyles[run.status] ?? runStatusStyles.failed;
+                  const style = RUN_STATUS_STYLES[run.status] ?? RUN_STATUS_STYLES.failed;
                   const isExpanded = expandedRunId === run.id;
                   const hasDetails = run.request_sent || run.response_body || run.error;
                   return (

--- a/src/pages/PostActionsListPage.tsx
+++ b/src/pages/PostActionsListPage.tsx
@@ -6,21 +6,7 @@ import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { EmptyState } from '../components/EmptyState';
 import { toast } from '../components/Toast';
 import { friendlyError } from '../utils/errors';
-
-const METHOD_COLORS: Record<string, string> = {
-  GET: 'bg-green-500/20 text-green-400',
-  POST: 'bg-blue-500/20 text-blue-400',
-  PUT: 'bg-yellow-500/20 text-yellow-400',
-  PATCH: 'bg-orange-500/20 text-orange-400',
-  DELETE: 'bg-red-500/20 text-red-400',
-};
-
-const AUTH_LABELS: Record<string, string> = {
-  none: 'No Auth',
-  bearer: 'Bearer',
-  basic: 'Basic',
-  header: 'Custom Header',
-};
+import { METHOD_COLORS, AUTH_LABELS } from '../utils/format';
 
 export function PostActionsListPage() {
   const [actions, setActions] = useState<PostAction[]>([]);

--- a/src/pages/ScheduleDetailPage.tsx
+++ b/src/pages/ScheduleDetailPage.tsx
@@ -7,58 +7,10 @@ import { friendlyError } from '../utils/errors';
 import { cronToHuman } from '../utils/cron';
 import { MarkdownRenderer } from '../components/Markdown';
 import { PostActionBindingsSection } from '../components/PostActionBindingsSection';
-
-const runStatusStyles: Record<string, { bg: string; dot: string; pulse: boolean }> = {
-  running: { bg: 'bg-blue-500/20 text-blue-400', dot: 'bg-blue-400', pulse: true },
-  success: { bg: 'bg-green-500/20 text-green-400', dot: 'bg-green-400', pulse: false },
-  failed: { bg: 'bg-red-500/20 text-red-400', dot: 'bg-red-400', pulse: false },
-  timeout: { bg: 'bg-yellow-500/20 text-yellow-400', dot: 'bg-yellow-400', pulse: false },
-};
+import { formatDateTime, formatDuration, sanitizeRunError, RUN_STATUS_STYLES } from '../utils/format';
 
 const BASE_POLL_INTERVAL = 10_000;
 const MAX_POLL_INTERVAL = 120_000;
-
-/** Strips potential stack traces, file paths, and sensitive data from error messages. */
-function sanitizeRunError(error: string | null | undefined): string {
-  if (!error) return '-';
-
-  // Strip file paths (unix and windows)
-  let sanitized = error.replace(/\/[\w./-]+/g, '[path]');
-  sanitized = sanitized.replace(/[A-Z]:\\[\w.\\-]+/gi, '[path]');
-
-  // Strip anything that looks like an API key or token (long hex/base64 strings)
-  sanitized = sanitized.replace(/\b[A-Za-z0-9+/=_-]{32,}\b/g, '[redacted]');
-
-  // Strip stack trace lines (e.g. "at Function.run (/app/...)")
-  sanitized = sanitized.replace(/\s+at\s+.+/g, '');
-
-  // Truncate to a safe display length
-  const MAX_LEN = 200;
-  if (sanitized.length > MAX_LEN) {
-    sanitized = sanitized.slice(0, MAX_LEN) + '...';
-  }
-
-  return sanitized.trim() || 'Execution failed';
-}
-
-function formatDuration(start: string, end: string | null): string {
-  if (!end) return 'Running...';
-  const ms = new Date(end).getTime() - new Date(start).getTime();
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainSec = seconds % 60;
-  if (minutes < 60) return `${minutes}m ${remainSec}s`;
-  const hours = Math.floor(minutes / 60);
-  const remainMin = minutes % 60;
-  return `${hours}h ${remainMin}m`;
-}
-
-function formatDateTime(dateStr: string | null): string {
-  if (!dateStr) return 'N/A';
-  return new Date(dateStr).toLocaleString();
-}
 
 export function ScheduleDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -339,7 +291,7 @@ export function ScheduleDetailPage() {
               </thead>
               <tbody className="divide-y divide-slate-800">
                 {runs.map((run) => {
-                  const style = runStatusStyles[run.status] ?? runStatusStyles.failed;
+                  const style = RUN_STATUS_STYLES[run.status] ?? RUN_STATUS_STYLES.failed;
                   const isExpanded = expandedRunId === run.id;
                   const hasConversation = run.prompt_sent || run.response_received;
                   return (

--- a/src/pages/SchedulesListPage.tsx
+++ b/src/pages/SchedulesListPage.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '../components/EmptyState';
 import { toast } from '../components/Toast';
 import { friendlyError } from '../utils/errors';
 import { cronToHuman } from '../utils/cron';
+import { formatRelativeTime } from '../utils/format';
 
 function scheduleStatusColor(schedule: Schedule): { bg: string; dot: string; pulse: boolean; label: string } {
   if (schedule.status === 'running') {
@@ -19,25 +20,6 @@ function scheduleStatusColor(schedule: Schedule): { bg: string; dot: string; pul
     return { bg: 'bg-slate-500/20 text-slate-400', dot: 'bg-slate-400', pulse: false, label: 'disabled' };
   }
   return { bg: 'bg-green-500/20 text-green-400', dot: 'bg-green-400', pulse: false, label: 'idle' };
-}
-
-function formatRelativeTime(dateStr: string | null): string {
-  if (!dateStr) return 'Never';
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = date.getTime() - now.getTime();
-  const absDiffMs = Math.abs(diffMs);
-
-  if (absDiffMs < 60_000) return diffMs > 0 ? 'in < 1m' : '< 1m ago';
-
-  const minutes = Math.floor(absDiffMs / 60_000);
-  if (minutes < 60) return diffMs > 0 ? `in ${minutes}m` : `${minutes}m ago`;
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return diffMs > 0 ? `in ${hours}h` : `${hours}h ago`;
-
-  const days = Math.floor(hours / 24);
-  return diffMs > 0 ? `in ${days}d` : `${days}d ago`;
 }
 
 export function SchedulesListPage() {

--- a/src/pages/WebhookDetailPage.tsx
+++ b/src/pages/WebhookDetailPage.tsx
@@ -7,48 +7,10 @@ import { friendlyError } from '../utils/errors';
 import { copyToClipboard } from '../utils/clipboard';
 import { MarkdownRenderer } from '../components/Markdown';
 import { PostActionBindingsSection } from '../components/PostActionBindingsSection';
-
-const runStatusStyles: Record<string, { bg: string; dot: string; pulse: boolean }> = {
-  running: { bg: 'bg-blue-500/20 text-blue-400', dot: 'bg-blue-400', pulse: true },
-  success: { bg: 'bg-green-500/20 text-green-400', dot: 'bg-green-400', pulse: false },
-  failed: { bg: 'bg-red-500/20 text-red-400', dot: 'bg-red-400', pulse: false },
-  timeout: { bg: 'bg-yellow-500/20 text-yellow-400', dot: 'bg-yellow-400', pulse: false },
-};
+import { formatDateTime, formatDuration, sanitizeRunError, RUN_STATUS_STYLES } from '../utils/format';
 
 const BASE_POLL_INTERVAL = 10_000;
 const MAX_POLL_INTERVAL = 120_000;
-
-function sanitizeRunError(error: string | null | undefined): string {
-  if (!error) return '-';
-  let sanitized = error.replace(/\/[\w./-]+/g, '[path]');
-  sanitized = sanitized.replace(/[A-Z]:\\[\w.\\-]+/gi, '[path]');
-  sanitized = sanitized.replace(/\b[A-Za-z0-9+/=_-]{32,}\b/g, '[redacted]');
-  sanitized = sanitized.replace(/\s+at\s+.+/g, '');
-  const MAX_LEN = 200;
-  if (sanitized.length > MAX_LEN) {
-    sanitized = sanitized.slice(0, MAX_LEN) + '...';
-  }
-  return sanitized.trim() || 'Execution failed';
-}
-
-function formatDuration(start: string, end: string | null): string {
-  if (!end) return 'Running...';
-  const ms = new Date(end).getTime() - new Date(start).getTime();
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainSec = seconds % 60;
-  if (minutes < 60) return `${minutes}m ${remainSec}s`;
-  const hours = Math.floor(minutes / 60);
-  const remainMin = minutes % 60;
-  return `${hours}h ${remainMin}m`;
-}
-
-function formatDateTime(dateStr: string | null): string {
-  if (!dateStr) return 'N/A';
-  return new Date(dateStr).toLocaleString();
-}
 
 export function WebhookDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -387,7 +349,7 @@ export function WebhookDetailPage() {
               </thead>
               <tbody className="divide-y divide-slate-800">
                 {runs.map((run) => {
-                  const style = runStatusStyles[run.status] ?? runStatusStyles.failed;
+                  const style = RUN_STATUS_STYLES[run.status] ?? RUN_STATUS_STYLES.failed;
                   const isExpanded = expandedRunId === run.id;
                   const hasConversation = run.prompt_sent || run.response_received;
                   return (

--- a/src/pages/WebhooksListPage.tsx
+++ b/src/pages/WebhooksListPage.tsx
@@ -6,6 +6,7 @@ import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { EmptyState } from '../components/EmptyState';
 import { toast } from '../components/Toast';
 import { friendlyError } from '../utils/errors';
+import { formatRelativeTime } from '../utils/format';
 
 function webhookStatusColor(webhook: Webhook): { bg: string; dot: string; pulse: boolean; label: string } {
   if (webhook.status === 'running') {
@@ -15,25 +16,6 @@ function webhookStatusColor(webhook: Webhook): { bg: string; dot: string; pulse:
     return { bg: 'bg-slate-500/20 text-slate-400', dot: 'bg-slate-400', pulse: false, label: 'disabled' };
   }
   return { bg: 'bg-green-500/20 text-green-400', dot: 'bg-green-400', pulse: false, label: 'idle' };
-}
-
-function formatRelativeTime(dateStr: string | null): string {
-  if (!dateStr) return 'Never';
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = date.getTime() - now.getTime();
-  const absDiffMs = Math.abs(diffMs);
-
-  if (absDiffMs < 60_000) return diffMs > 0 ? 'in < 1m' : '< 1m ago';
-
-  const minutes = Math.floor(absDiffMs / 60_000);
-  if (minutes < 60) return diffMs > 0 ? `in ${minutes}m` : `${minutes}m ago`;
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return diffMs > 0 ? `in ${hours}h` : `${hours}h ago`;
-
-  const days = Math.floor(hours / 24);
-  return diffMs > 0 ? `in ${days}d` : `${days}d ago`;
 }
 
 export function WebhooksListPage() {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,91 @@
+/**
+ * Format a date string as a locale-aware date-time.
+ */
+export function formatDateTime(dateStr: string | null): string {
+  if (!dateStr) return 'N/A';
+  return new Date(dateStr).toLocaleString();
+}
+
+/**
+ * Format the duration between two ISO timestamps.
+ */
+export function formatDuration(start: string, end: string | null): string {
+  if (!end) return 'Running...';
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainSec = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remainSec}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainMin = minutes % 60;
+  return `${hours}h ${remainMin}m`;
+}
+
+/**
+ * Format a date string as a human-readable relative time (e.g. "5m ago", "in 2h").
+ */
+export function formatRelativeTime(dateStr: string | null): string {
+  if (!dateStr) return 'Never';
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+  const absDiffMs = Math.abs(diffMs);
+
+  if (absDiffMs < 60_000) return diffMs > 0 ? 'in < 1m' : '< 1m ago';
+
+  const minutes = Math.floor(absDiffMs / 60_000);
+  if (minutes < 60) return diffMs > 0 ? `in ${minutes}m` : `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return diffMs > 0 ? `in ${hours}h` : `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return diffMs > 0 ? `in ${days}d` : `${days}d ago`;
+}
+
+/**
+ * Strip potential stack traces, file paths, and sensitive tokens from run error messages.
+ */
+export function sanitizeRunError(error: string | null | undefined): string {
+  if (!error) return '-';
+
+  let sanitized = error.replace(/\/[\w./-]+/g, '[path]');
+  sanitized = sanitized.replace(/[A-Z]:\\[\w.\\-]+/gi, '[path]');
+  sanitized = sanitized.replace(/\b[A-Za-z0-9+/=_-]{32,}\b/g, '[redacted]');
+  sanitized = sanitized.replace(/\s+at\s+.+/g, '');
+
+  const MAX_LEN = 200;
+  if (sanitized.length > MAX_LEN) {
+    sanitized = sanitized.slice(0, MAX_LEN) + '...';
+  }
+
+  return sanitized.trim() || 'Execution failed';
+}
+
+/** Tailwind classes for run status badges used across detail pages. */
+export const RUN_STATUS_STYLES: Record<string, { bg: string; dot: string; pulse: boolean }> = {
+  running: { bg: 'bg-blue-500/20 text-blue-400', dot: 'bg-blue-400', pulse: true },
+  success: { bg: 'bg-green-500/20 text-green-400', dot: 'bg-green-400', pulse: false },
+  failed: { bg: 'bg-red-500/20 text-red-400', dot: 'bg-red-400', pulse: false },
+  timeout: { bg: 'bg-yellow-500/20 text-yellow-400', dot: 'bg-yellow-400', pulse: false },
+  retrying: { bg: 'bg-yellow-500/20 text-yellow-400', dot: 'bg-yellow-400', pulse: true },
+};
+
+/** Tailwind badge colors per HTTP method. */
+export const METHOD_COLORS: Record<string, string> = {
+  GET: 'bg-green-500/20 text-green-400',
+  POST: 'bg-blue-500/20 text-blue-400',
+  PUT: 'bg-yellow-500/20 text-yellow-400',
+  PATCH: 'bg-orange-500/20 text-orange-400',
+  DELETE: 'bg-red-500/20 text-red-400',
+};
+
+/** Human-readable labels for post-action auth types. */
+export const AUTH_LABELS: Record<string, string> = {
+  none: 'No Auth',
+  bearer: 'Bearer Token',
+  basic: 'Basic Auth',
+  header: 'Custom Header',
+};


### PR DESCRIPTION
## Problem

Six pages (`ScheduleDetailPage`, `WebhookDetailPage`, `PostActionDetailPage`, `PostActionsListPage`, `SchedulesListPage`, `WebhooksListPage`) each defined their own copy of the same helpers:

- `formatDateTime` — duplicated in 3 pages
- `formatDuration` — duplicated in 3 pages
- `formatRelativeTime` — duplicated in 2 pages
- `sanitizeRunError` — duplicated in 2 pages
- `runStatusStyles` / `RUN_STATUS_STYLES` — duplicated in 3 pages
- `METHOD_COLORS` — duplicated in 2 pages
- `AUTH_LABELS` — duplicated in 2 pages (with inconsistent values, see below)

Additionally, `PostActionDetailPage` had a bug in its local `formatDuration`: it was missing the hours branch, so runs longer than 60 minutes displayed as `90m 30s` instead of `1h 30m`.

`AUTH_LABELS` had inconsistent values between pages:
- List page: `bearer: 'Bearer'`, `basic: 'Basic'`
- Detail page: `bearer: 'Bearer Token'`, `basic: 'Basic Auth'`

## Solution

Create `src/utils/format.ts` with all shared helpers and remove the local definitions from each page.

```
src/utils/format.ts  (new)
├── formatDateTime(dateStr)
├── formatDuration(start, end)    ← fixed: now includes hours branch
├── formatRelativeTime(dateStr)
├── sanitizeRunError(error)
├── RUN_STATUS_STYLES             ← renamed to UPPER_CASE (exported constant)
├── METHOD_COLORS
└── AUTH_LABELS                   ← unified: 'Bearer Token' / 'Basic Auth'
```

## Changes

| File | Change |
|------|--------|
| `src/utils/format.ts` | New file — consolidated helpers |
| `src/pages/PostActionDetailPage.tsx` | Remove 5 local definitions → import from utils; `formatDuration` bug fixed |
| `src/pages/ScheduleDetailPage.tsx` | Remove 4 local definitions → import from utils |
| `src/pages/WebhookDetailPage.tsx` | Remove 4 local definitions → import from utils |
| `src/pages/PostActionsListPage.tsx` | Remove 2 local definitions → import from utils |
| `src/pages/SchedulesListPage.tsx` | Remove 1 local definition → import from utils |
| `src/pages/WebhooksListPage.tsx` | Remove 1 local definition → import from utils |

## Bug fixed

`PostActionDetailPage.formatDuration` before:
```ts
const minutes = Math.floor(seconds / 60);
return `${minutes}m ${seconds % 60}s`;  // 90m 30s ← wrong for long runs
```

After (via shared util):
```ts
if (minutes < 60) return `${minutes}m ${remainSec}s`;
const hours = Math.floor(minutes / 60);
return `${hours}h ${minutes % 60}m`;    // 1h 30m ← correct
```

## Testing

- `npm run build` passes with zero TypeScript errors
- No behavior changes outside the `formatDuration` bug fix