### PR TITLE
fix: resync UI on toggle error + throw on clipboard fallback failure

### DIFF
--- a/src/pages/PostActionsListPage.tsx
+++ b/src/pages/PostActionsListPage.tsx
@@ -56,6 +56,7 @@ export function PostActionsListPage() {
       fetchActions();
     } catch (err) {
       toast('error', friendlyError(err, 'Failed to toggle post-action.'));
+      fetchActions();
     } finally {
       setTogglingId(null);
     }

--- a/src/pages/ScheduleDetailPage.tsx
+++ b/src/pages/ScheduleDetailPage.tsx
@@ -130,6 +130,7 @@ export function ScheduleDetailPage() {
       fetchSchedule();
     } catch (err) {
       toast('error', friendlyError(err, 'Failed to toggle schedule.'));
+      fetchSchedule();
     } finally {
       setTogglingEnabled(false);
     }

--- a/src/pages/SchedulesListPage.tsx
+++ b/src/pages/SchedulesListPage.tsx
@@ -74,6 +74,7 @@ export function SchedulesListPage() {
       fetchSchedules();
     } catch (err) {
       toast('error', friendlyError(err, 'Failed to toggle schedule.'));
+      fetchSchedules();
     } finally {
       setTogglingId(null);
     }

--- a/src/pages/WebhookDetailPage.tsx
+++ b/src/pages/WebhookDetailPage.tsx
@@ -129,6 +129,7 @@ export function WebhookDetailPage() {
       fetchWebhook();
     } catch (err) {
       toast('error', friendlyError(err, 'Failed to toggle webhook.'));
+      fetchWebhook();
     } finally {
       setTogglingEnabled(false);
     }

--- a/src/pages/WebhooksListPage.tsx
+++ b/src/pages/WebhooksListPage.tsx
@@ -70,6 +70,7 @@ export function WebhooksListPage() {
       fetchWebhooks();
     } catch (err) {
       toast('error', friendlyError(err, 'Failed to toggle webhook.'));
+      fetchWebhooks();
     } finally {
       setTogglingId(null);
     }

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -17,7 +17,10 @@ export async function copyToClipboard(text: string): Promise<void> {
   document.body.appendChild(textarea);
   textarea.select();
   try {
-    document.execCommand('copy');
+    const success = document.execCommand('copy');
+    if (!success) {
+      throw new Error('execCommand copy failed');
+    }
   } finally {
     document.body.removeChild(textarea);
   }


### PR DESCRIPTION
## Problem

Two unrelated but small bugs found during audit:

### 1. Toggle handlers leave UI stale on error

In all five pages that have an enable/disable toggle (`SchedulesListPage`, `WebhooksListPage`, `PostActionsListPage`, `ScheduleDetailPage`, `WebhookDetailPage`), the `handleToggle` function called `fetchX()` on success but **not on error**:

```ts
try {
  await api.update(id, { enabled: !item.enabled });
  toast('success', ...);
  fetchItems();  // ← only called here
} catch (err) {
  toast('error', ...);
  // ← no fetch — UI stays at the optimistic/stale state
}
```

If the API call fails (network error, 500, etc.), the toggle switch visually snaps back to its pre-click state only after the next background poll (up to 10 seconds later). Users see the toggle appear to "hang" in the wrong position.

### 2. `execCommand('copy')` failure is silently swallowed

`src/utils/clipboard.ts` has an HTTP fallback for non-secure contexts. `document.execCommand('copy')` returns `false` when the copy fails (e.g. browser policy), but the return value was ignored:

```ts
document.execCommand('copy');  // false = silent failure
```

Callers received no error, showed no feedback, and the user assumed the copy succeeded.

## Fix

### 1. Add `fetchX()` to the catch block in all five toggle handlers

```ts
} catch (err) {
  toast('error', friendlyError(err, 'Failed to toggle.'));
  fetchItems();  // ← re-sync immediately instead of waiting for poll
}
```

No double-fetch on the happy path — `catch` only runs when `try` throws.

### 2. Throw if `execCommand` returns false

```ts
const success = document.execCommand('copy');
if (!success) throw new Error('execCommand copy failed');
```

The `finally` block still runs to remove the temporary textarea. Callers already have `try/catch` that display a `toast('error', 'Failed to copy to clipboard')`.

## Changes

| File | Change |
|------|--------|
| `src/pages/SchedulesListPage.tsx` | Add `fetchSchedules()` in `handleToggle` catch |
| `src/pages/WebhooksListPage.tsx` | Add `fetchWebhooks()` in `handleToggle` catch |
| `src/pages/PostActionsListPage.tsx` | Add `fetchActions()` in `handleToggle` catch |
| `src/pages/ScheduleDetailPage.tsx` | Add `fetchSchedule()` in `handleToggle` catch |
| `src/pages/WebhookDetailPage.tsx` | Add `fetchWebhook()` in `handleToggle` catch |
| `src/utils/clipboard.ts` | Throw on `execCommand('copy')` returning false |

## Testing

- `npm run build` passes with zero TypeScript errors
- Toggle error: manually returning a 500 from the API now immediately re-renders the correct state
- Clipboard: `execCommand` returning false now surfaces as an error toast instead of silent no-op