### PR TITLE
fix(post-actions): sanitize run.error before rendering

### DIFF
--- a/src/pages/PostActionDetailPage.tsx
+++ b/src/pages/PostActionDetailPage.tsx
@@ -55,6 +55,14 @@ function formatDuration(start: string, end: string | null): string {
   return `${minutes}m ${remainSec}s`;
 }
 
+function sanitizeRunError(error: string | null | undefined): string {
+  if (!error) return '-';
+  let sanitized = error.replace(/\/[\w./-]+/g, '[path]');
+  sanitized = sanitized.replace(/[A-Z]:\\[\w.\\-]+/gi, '[path]');
+  sanitized = sanitized.replace(/\b[A-Za-z0-9+/=_-]{32,}\b/g, '[redacted]');
+  return sanitized;
+}
+
 export function PostActionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -518,7 +526,7 @@ export function PostActionDetailPage() {
                         {formatDuration(run.triggered_at, run.completed_at)}
                       </td>
                       <td className="max-w-xs truncate py-2.5 text-xs text-red-400">
-                        {run.error || '-'}
+                        {sanitizeRunError(run.error)}
                       </td>
                     </tr>
                   );
@@ -552,7 +560,7 @@ export function PostActionDetailPage() {
                     <div>
                       <p className="mb-1 text-[10px] font-medium text-red-400">Error</p>
                       <pre className="overflow-x-auto rounded bg-slate-800 p-2 font-mono text-xs text-red-300">
-                        {run.error}
+                        {sanitizeRunError(run.error)}
                       </pre>
                     </div>
                   )}


### PR DESCRIPTION
## Problem

`PostActionDetailPage` rendered `run.error` directly in two places:

- The **table cell** (last column of the runs table): `{run.error || '-'}`
- The **expanded detail panel**: `{run.error}`

`ScheduleDetailPage` and `WebhookDetailPage` both apply a `sanitizeRunError()` function before rendering error strings. `PostActionDetailPage` was inconsistent and exposed raw error messages to the user, which can contain:

- Internal **file paths** (e.g. `/app/internal/runner.go:42`)
- **API keys or tokens** embedded in error messages (e.g. from failed HTTP calls with auth headers)

## Fix

Added `sanitizeRunError` locally (identical implementation to the other detail pages) and applied it to both rendering sites:

```tsx
// Before
{run.error || '-'}
{run.error}

// After
{sanitizeRunError(run.error)}  // returns '-' when null/undefined
{sanitizeRunError(run.error)}
```

The function strips Unix/Windows file paths and redacts strings that look like secrets (hex/base64 ≥ 32 chars).

## Changes

| File | Change |
|------|--------|
| `src/pages/PostActionDetailPage.tsx` | Add `sanitizeRunError` + apply to both `run.error` render sites |

## Testing

- `npm run build` passes with zero TypeScript errors
- Behavior is now consistent with `ScheduleDetailPage` and `WebhookDetailPage`

> **Note:** `sanitizeRunError` will be deduplicated into `src/utils/format.ts` via PR #62 (`refactor/shared-format-utils`). This fix is intentionally self-contained to unblock the security issue independently of the refactor.